### PR TITLE
[DominikLesniewski] Kuba Kern's NWD suggested changes

### DIFF
--- a/KubaKern/NWD/Main.java
+++ b/KubaKern/NWD/Main.java
@@ -16,7 +16,7 @@ public class Main {
         for (int i=0;i<n;i++) {
             System.out.println(tab[i]);
         }
-
+        scan.close();
     }
     static int nwd(int a, int b) {
         while (a != b)


### PR DESCRIPTION
- added scanner.close() at the end of the main()
- (optional) you can consider not using an array there, most of the time in SPOJ exercises you can calculate and print the output for each input line; there's no need to store all of the values