### PR TITLE
[Michał Plewa] Update zliczacz_liter.cpp

### DIFF
--- a/WeronikaDemich/ZliczaczLiter/zliczacz_liter.cpp
+++ b/WeronikaDemich/ZliczaczLiter/zliczacz_liter.cpp
@@ -34,6 +34,4 @@ int main()
         if(chars[i] != 0)
             std::cout << char(i) << ' ' << chars[i] << '\n';
     }
-
-    return 0;
 }


### PR DESCRIPTION
return 0 w funkcji main nie jest wymagany.
Dodatkowo można się zastanowić nad użyciem przestrzeni nazw std, ponieważ inna przestrzeń nazw nie jest używana.
Zwiększyłoby to czytelność kodu.